### PR TITLE
Update simulations.jl

### DIFF
--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -44,7 +44,7 @@ function now(sim::Simulation)
   sim.time
 end
 
-function now(ev::Event)
+function now(ev::AbstractEvent)
   return now(environment(ev))
 end
 

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -44,6 +44,10 @@ function now(sim::Simulation)
   sim.time
 end
 
+function now(ev::Event)
+  return now(environment(ev))
+end
+
 function active_process(sim::Simulation) :: AbstractProcess
   get(sim.active_proc)
 end


### PR DESCRIPTION
Addition of a function now(ev::Event).

The function is similar to call now(environment(ev)) but allows shortcuts when writing event callbacks using the simulation time.