### PR TITLE
Create basic M/M/c queue example

### DIFF
--- a/docs/src/examples/mmc.md
+++ b/docs/src/examples/mmc.md
@@ -1,0 +1,74 @@
+# Multi-server Queue
+  
+## Description
+
+An [M/M/c queue](https://en.wikipedia.org/wiki/M/M/c_queue) is a basic queue with _c_ identical servers, exponentially distributed interarrival times, and exponentially distributed service times for each server. The arrival rate is defined as _λ_ such that the interarrival time distribution has mean _1/λ_. Similarly, the service rate is defined as _μ_ such that the service time distribution has mean _1/μ_ (for each server). The overall traffic intensity of the queue is _ρ = λ / (c * μ)_. If the traffic intensity exceeds one, the queue is unstable and the queue length will grow indefinitely. 
+
+## Code
+
+```julia
+#set simulation parameters
+srand(8710) # set random number seed for reproducibility
+num_customers = 10 # total number of customers generated
+
+# set queue parameters
+num_servers = 2 # number of servers
+mu = 1.0 / 2 # service rate
+lam = 0.9 # arrival rate
+arrival_dist = Exponential(1 / lam) # interarrival time distriubtion
+service_dist = Exponential(1 / mu) # service time distribution
+
+# define customer behavior
+@resumable function customer(env::Environment, server::Resource, id::Integer, t_a::Float64, d_s::Distribution)
+    @yield timeout(env, t_a) # customer arrives
+    println("Customer $id arrived: ", now(env))
+    @yield request(server) # customer starts service
+    println("Customer $id entered service: ", now(env))
+    @yield timeout(env, rand(d_s)) # server is busy
+    @yield release(server) # customer exits service
+    println("Customer $id exited service: ", now(env))
+end
+
+# setup and run simulation
+sim = Simulation() # initialize simulation environment
+server = Resource(sim, num_servers) # initialize servers
+arrival_time = 0.0
+for i = 1:num_customers # initialize customers
+    arrival_time += rand(arrival_dist)
+    @process customer(sim, server, i, arrival_time, service_dist)
+end
+run(sim) # run simulation
+
+## output
+#
+# Customer 1 arrived: 0.1229193244813443
+# Customer 1 entered service: 0.1229193244813443
+# Customer 2 arrived: 0.22607641035584877
+# Customer 2 entered service: 0.22607641035584877
+# Customer 3 arrived: 0.4570009029409502
+# Customer 2 exited service: 1.7657345101378559
+# Customer 3 entered service: 1.7657345101378559
+# Customer 1 exited service: 2.154824561031012
+# Customer 3 exited service: 2.2765287086137764
+# Customer 4 arrived: 2.3661687470062995
+# Customer 4 entered service: 2.3661687470062995
+# Customer 5 arrived: 2.6110816119637885
+# Customer 5 entered service: 2.6110816119637885
+# Customer 5 exited service: 2.8017888690417583
+# Customer 6 arrived: 3.019540357955037
+# Customer 6 entered service: 3.019540357955037
+# Customer 6 exited service: 3.351151832298383
+# Customer 7 arrived: 3.5254699872847612
+# Customer 7 entered service: 3.5254699872847612
+# Customer 7 exited service: 4.261422043181396
+# Customer 4 exited service: 4.602071952938201
+# Customer 8 arrived: 7.27536704811686
+# Customer 8 entered service: 7.27536704811686
+# Customer 9 arrived: 7.491176033637809
+# Customer 9 entered service: 7.491176033637809
+# Customer 10 arrived: 8.39098457094977
+# Customer 8 exited service: 8.683396356977969
+# Customer 10 entered service: 8.683396356977969
+# Customer 9 exited service: 8.7501656586875
+# Customer 10 exited service: 9.049670951561666
+```

--- a/examples/queue_mmc.ipynb
+++ b/examples/queue_mmc.ipynb
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define customer behavior"
+    "### Define Customer Behavior"
    ]
   },
   {

--- a/examples/queue_mmc.ipynb
+++ b/examples/queue_mmc.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-server Queue\n",
+    "\n",
+    "## Description \n",
+    "An [M/M/c queue](https://en.wikipedia.org/wiki/M/M/c_queue) is a basic queue with $c$ identical servers, exponentially distributed interarrival times, and exponentially distributed service times for each server. The arrival rate is defined as $\\lambda$ such that the interarrival time distribution has mean $1/\\lambda$. Similarly, the service rate is defined as $\\mu$ such that the service time distribution has mean $1/\\mu$ (for each server). The overall traffic intensity of the queue is $\\rho = \\lambda / (c \\mu)$. If the traffic intensity exceeds one, the queue is unstable and the queue length will grow indefinitely. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Pkg.add(\"Distributions\")\n",
+    "Pkg.add(\"SimJulia\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mPrecompiling module Distributions.\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mPrecompiling module SimJulia.\n",
+      "\u001b[39m"
+     ]
+    }
+   ],
+   "source": [
+    "using Distributions\n",
+    "using SimJulia, ResumableFunctions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "srand(8710) # set random number seed for reproducibility\n",
+    "num_customers = 10 # total number of customers generated\n",
+    "num_servers = 2 # number of servers\n",
+    "mu = 1.0 / 2 # service rate\n",
+    "lam = 0.9 # arrival rate\n",
+    "arrival_dist = Exponential(1 / lam) # interarrival time distriubtion\n",
+    "service_dist = Exponential(1 / mu); # service time distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define customer behavior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "customer (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@resumable function customer(env::Environment, server::Resource, id::Integer, time_arr::Float64, dist_serve::Distribution)\n",
+    "    @yield timeout(env, time_arr) # customer arrives\n",
+    "    println(\"Customer $id arrived: \", now(env))\n",
+    "    @yield request(server) # customer starts service\n",
+    "    println(\"Customer $id entered service: \", now(env))\n",
+    "    @yield timeout(env, rand(dist_serve)) # server is busy\n",
+    "    @yield release(server) # customer exits service\n",
+    "    println(\"Customer $id exited service: \", now(env))\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup and Run Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Customer 1 arrived: 0.1229193244813443\n",
+      "Customer 1 entered service: 0.1229193244813443\n",
+      "Customer 2 arrived: 0.22607641035584877\n",
+      "Customer 2 entered service: 0.22607641035584877\n",
+      "Customer 3 arrived: 0.4570009029409502\n",
+      "Customer 2 exited service: 1.7657345101378559\n",
+      "Customer 3 entered service: 1.7657345101378559\n",
+      "Customer 1 exited service: 2.154824561031012\n",
+      "Customer 3 exited service: 2.2765287086137764\n",
+      "Customer 4 arrived: 2.3661687470062995\n",
+      "Customer 4 entered service: 2.3661687470062995\n",
+      "Customer 5 arrived: 2.6110816119637885\n",
+      "Customer 5 entered service: 2.6110816119637885\n",
+      "Customer 5 exited service: 2.8017888690417583\n",
+      "Customer 6 arrived: 3.019540357955037\n",
+      "Customer 6 entered service: 3.019540357955037\n",
+      "Customer 6 exited service: 3.351151832298383\n",
+      "Customer 7 arrived: 3.5254699872847612\n",
+      "Customer 7 entered service: 3.5254699872847612\n",
+      "Customer 7 exited service: 4.261422043181396\n",
+      "Customer 4 exited service: 4.602071952938201\n",
+      "Customer 8 arrived: 7.27536704811686\n",
+      "Customer 8 entered service: 7.27536704811686\n",
+      "Customer 9 arrived: 7.491176033637809\n",
+      "Customer 9 entered service: 7.491176033637809\n",
+      "Customer 10 arrived: 8.39098457094977\n",
+      "Customer 8 exited service: 8.683396356977969\n",
+      "Customer 10 entered service: 8.683396356977969\n",
+      "Customer 9 exited service: 8.7501656586875\n",
+      "Customer 10 exited service: 9.049670951561666\n"
+     ]
+    }
+   ],
+   "source": [
+    "sim = Simulation() # initialize simulation environment\n",
+    "server = Resource(sim, num_servers) # initialize servers\n",
+    "arrival_time = 0.0\n",
+    "for i = 1:num_customers # initialize customers\n",
+    "    arrival_time += rand(arrival_dist)\n",
+    "    @process customer(sim, server, i, arrival_time, service_dist)\n",
+    "end\n",
+    "run(sim) # run simulation"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.0",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A simple M/M/c queue might be a nice addition to the examples. I'm not sure if this is the most straightforward way to deal with the arrival times. Maybe there's a way to pass an arrival distribution and a service distribution to customer (instead of an arrival time and a service distribution).