### PR TITLE
Changed the type of process priorities from Int8 to Int (Julia v0.7+)

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -63,7 +63,7 @@ function remove_callback(cb::Function, ev::AbstractEvent)
   i != 0 && deleteat!(ev.bev.callbacks, i)
 end
 
-function schedule(ev::AbstractEvent, delay::Number=zero(Float64); priority::Int8=zero(Int8), value::Any=nothing)
+function schedule(ev::AbstractEvent, delay::Number=zero(Float64); priority::Int=0, value::Any=nothing)
   state(ev) == processed && throw(EventProcessed(ev))
   env = environment(ev)
   bev = ev.bev

--- a/src/events.jl
+++ b/src/events.jl
@@ -5,12 +5,12 @@ struct Event <: AbstractEvent
   end
 end
 
-function succeed(ev::Event; priority::Int8=zero(Int8), value::Any=nothing) :: Event
+function succeed(ev::Event; priority::Int=0, value::Any=nothing) :: Event
   state(ev) != idle && throw(EventNotIdle(ev))
   schedule(ev; priority=priority, value=value)
 end
 
-function fail(ev::Event, exc::Exception; priority::Int8=zero(Int8)) :: Event
+function fail(ev::Event, exc::Exception; priority::Int=0) :: Event
   succeed(ev; priority=priority, value=exc)
 end
 
@@ -21,7 +21,7 @@ struct Timeout <: AbstractEvent
   end
 end
 
-function timeout(env::Environment, delay::Number=0; priority::Int8=zero(Int8), value::Any=nothing)
+function timeout(env::Environment, delay::Number=0; priority::Int=0, value::Any=nothing)
   schedule(Timeout(env), delay; priority=priority, value=value)
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -32,7 +32,7 @@ function check(ev::AbstractEvent, op::Operator, event_state_values::Dict{Abstrac
     end
   elseif state(op) == scheduled
     if isa(val, Exception)
-      schedule(op; priority=typemax(Int8), value=val)
+      schedule(op; priority=typemax(Int), value=val)
     else
       event_state_values[ev] = StateValue(state(ev), val)
     end

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -57,9 +57,9 @@ end
 function interrupt(proc::Process, cause::Any=nothing)
   env = environment(proc)
   if proc.fsmi._state != 0xff
-    proc.target isa Initialize && schedule(proc.target; priority=typemax(Int8))
-    target = schedule(Interrupt(env); priority=typemax(Int8), value=InterruptException(active_process(env), cause))
+    proc.target isa Initialize && schedule(proc.target; priority=typemax(Int))
+    target = schedule(Interrupt(env); priority=typemax(Int), value=InterruptException(active_process(env), cause))
     @callback execute_interrupt(target, proc)
   end
-  timeout(env; priority=typemax(Int8))
+  timeout(env; priority=typemax(Int))
 end

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -10,7 +10,7 @@ struct EmptySchedule <: Exception end
 
 struct EventKey
   time :: Float64
-  priority :: Int8
+  priority :: Int
   id :: UInt
 end
 

--- a/src/utils/time.jl
+++ b/src/utils/time.jl
@@ -6,7 +6,7 @@ function run(env::Environment, until::DateTime)
   run(env, Dates.datetime2epochms(until))
 end
 
-function timeout(env::Environment, delay::Period; priority::Int8=zero(Int8), value::Any=nothing)
+function timeout(env::Environment, delay::Period; priority::Int=0, value::Any=nothing)
   time = now(env)
   del = Dates.datetime2epochms(Dates.epochms2datetime(time)+delay)-time
   timeout(env, del; priority=priority, value=value)


### PR DESCRIPTION
- Changed the type of the priority field in the struct EventKey from Int8 to Int, to allow more precise control of priority for simultaneous events in a simulation.
- Changed the definition of the schedule and timeout functions to reflect the updated type.