### PR TITLE
Restored deprecated functions and extended resource request function

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -54,3 +54,11 @@ end
 function (|)(ev1::AbstractEvent, ev2::AbstractEvent)
   Operator(eval_or, ev1, ev2)
 end
+
+function AllOf(events::Vector{AbstractEvent})
+  Operator(eval_and, events...)
+end
+
+function AnyOf(events::Vector{AbstractEvent})
+  Operator(eval_or, events...)
+end

--- a/src/resources/containers.jl
+++ b/src/resources/containers.jl
@@ -32,6 +32,21 @@ end
 
 request(res::Resource; priority::Int=0) = put(res, 1; priority=priority)
 
+"""
+  request_any(res_options::Vector{Resource}; priority::Int=0)
+
+Request from a list of alternative resources.
+
+The resource with the shortest queue is selected.
+"""
+function request_any(res_alts::Vector{Resource}; priority::Int=0)
+  #find resource with the shortest put_queue
+  _, res_id = findmin(length.([res.put_queue for res in res_alts]))
+  #select the resource with the shortest put_queue
+  res = res_alts[res_id]
+  request(res; priority = priority)
+end
+
 function get(con::Container{N}, amount::N; priority::Int=0) where N<:Number
   get_ev = Get(con.env)
   con.get_queue[get_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)


### PR DESCRIPTION
Restored the AllOf and AnyOf conditional functions that existed in v0.3. These are useful for checking for predecessors to an event.
Also added a function request_any that allows for alternate resources to be used in a process. The function checks which of the resource alternatives listed has the shortest put_queue and selects that as the resource. This is valuable when there are different resource types and allows for features available in other DES software.