### PR TITLE
Bugfix in Containers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "SimJulia"
 uuid = "428bdadb-6287-5aa5-874b-9969638295fd"
-repo = "https://github.com/BenLauwens/SimJulia.jl.git"
 keywords = ["discrete-even simulation"]
 license = "MIT"
 desc = "A discrete event process oriented simulation framework."
 authors = ["Ben Lauwens <ben.lauwens@gmail.com>"]
-version = "0.8.1"
+repo = "https://github.com/BenLauwens/SimJulia.jl.git"
+version = "0.8.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -13,8 +13,8 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 
 [compat]
-julia = ">=1.2"
 ResumableFunctions = ">=0.5.1"
+julia = ">=1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/resources/containers.jl
+++ b/src/resources/containers.jl
@@ -1,28 +1,28 @@
-struct ContainerKey{N<:Number} <: ResourceKey
+struct ContainerKey{N<:Real} <: ResourceKey
   priority :: Int
   id :: UInt
   amount :: N
 end
 
-mutable struct Container{N<:Number} <: AbstractResource
+mutable struct Container{N<:Real} <: AbstractResource
   env :: Environment
   capacity :: N
   level :: N
   seid :: UInt
   put_queue :: DataStructures.PriorityQueue{Put, ContainerKey{N}}
   get_queue :: DataStructures.PriorityQueue{Get, ContainerKey{N}}
-  function Container{N}(env::Environment, capacity::N=one(N); level::N=zero(N)) where {N<:Number}
+  function Container{N}(env::Environment, capacity::N=one(N); level::N=zero(N)) where {N<:Real}
     new(env, capacity, level, zero(UInt), DataStructures.PriorityQueue{Put, ContainerKey{N}}(), DataStructures.PriorityQueue{Get, ContainerKey{N}}())
   end
 end
 
-function Container(env::Environment, capacity::N=one(N); level::N=zero(N)) where N<:Number
+function Container(env::Environment, capacity::N=one(N); level::N=zero(N)) where N<:Real
   Container{N}(env, capacity, level=level)
 end
 
 const Resource = Container{Int}
 
-function put(con::Container{N}, amount::N; priority::Int=0) where N<:Number
+function put(con::Container{N}, amount::N; priority::Int=0) where N<:Real
   put_ev = Put(con.env)
   con.put_queue[put_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
   @callback trigger_get(put_ev, con)
@@ -32,7 +32,7 @@ end
 
 request(res::Resource; priority::Int=0) = put(res, 1; priority=priority)
 
-function get(con::Container{N}, amount::N; priority::Int=0) where N<:Number
+function get(con::Container{N}, amount::N; priority::Int=0) where N<:Real
   get_ev = Get(con.env)
   con.get_queue[get_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
   @callback trigger_put(get_ev, con)
@@ -42,14 +42,14 @@ end
 
 release(res::Resource; priority::Int=0) = get(res, 1; priority=priority)
 
-function do_put(con::Container{N}, put_ev::Put, key::ContainerKey{N}) where N<:Number
+function do_put(con::Container{N}, put_ev::Put, key::ContainerKey{N}) where N<:Real
   con.level + key.amount > con.capacity && return false
   schedule(put_ev)
   con.level += key.amount
   true
 end
 
-function do_get(con::Container{N}, get_ev::Get, key::ContainerKey{N}) where N<:Number
+function do_get(con::Container{N}, get_ev::Get, key::ContainerKey{N}) where N<:Real
   con.level - key.amount < zero(N) && return false
   schedule(get_ev)
   con.level -= key.amount


### PR DESCRIPTION
Containers with Complex as the type of their capacity gave errors with put/get requests because z1 < z2 is normally not defined for complex numbers.
Solution: Containers have been restricted to subtypes of Real instead of Number.