### PR TITLE
Enable preemption of jobs in a queue

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -54,3 +54,19 @@ end
 function (|)(ev1::AbstractEvent, ev2::AbstractEvent)
   Operator(eval_or, ev1, ev2)
 end
+
+"""
+    AllOf(events::Vector{AbstractEvent})
+
+Check if all required predecessor events have been executed. Used in conjunction
+    with the `@yield` macro.
+"""
+AllOf(events) = Operator(SimJulia.eval_and,events...)
+
+"""
+    AnyOf(events::Vector{AbstractEvent})
+
+Check if at least one of the required predecessor events has been executed.
+    Used in conjunction with the `@yield` macro.
+"""
+AnyOf(events) = Operator(SimJulia.eval_or,events...)

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -54,12 +54,9 @@ function put(sto::Store{T}, item::T, preempt::Bool=false, filter::Function=get_a
         pitem = setdiff(stoitems, [itm for itm in sto.items])[1] #find removed item
         proc = pitem.process #process to interrupt
         interrupt(proc, item) #interrupt process on removed item identify item causing the preemption
-        #put new item into the queue
-        put_ev = put(sto, item, priority = item.priority)
-    else
-        put_ev = put(sto, item, priority = item.priority) #regular put if no preemption or not at full capactiy
     end
-    put_ev
+    #put new item into the queue
+    put(sto, item, priority = item.priority)
 end
 
 get_any_item(::T) where T = true

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -46,7 +46,7 @@ This method requires that T be a mutable struct with the fields:
 """
 function put(sto::Store{T}, item::T, preempt::Bool=false, filter::Function=get_any_item) where T
     @assert :priority in fieldnames(T) "Preemption requires that the item being stored have :priority as one of its fields."
-    @assert :process in fieldnames(T) && item.process isa Process "Preemption requires that the item being stored have :process (Dict) as one of its fields."
+    @assert :process in fieldnames(T) && item.process isa Process "Preemption requires that the item being stored have `:process` as one of its fields."
     if preempt && !isempty(sto.items) && item.priority < maximum([itm.priority for itm in sto.items]) #if the new item priority is higher than the priority of at least one of the items in the store, preempt
         #remove item from store
         stoitems = [itm for itm in sto.items] #original items in sto

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -23,7 +23,7 @@ mutable struct Store{T} <: AbstractResource
   end
 end
 
-function put(sto::Store{T}, item::T, priority::Int=0) where T
+function put(sto::Store{T}, item::T; priority::Int=0) where T
   put_ev = Put(sto.env)
   sto.put_queue[put_ev] = StorePutKey{T}(priority, sto.seid+=one(UInt), item)
   @callback trigger_get(put_ev, sto)
@@ -60,9 +60,9 @@ function put(sto::Store{T}, item::T, preempt::Bool=false, filter::Function=get_a
         pitem.time_in_service = now(pitem.process[sto].bev.env) - pitem.start_service #update time in service
         interrupt(pitem.process[sto],Preempted(item)) #interrupt process on removed item
         #put new item into the queue
-        put_ev = put(sto, item, item.priority)
+        put_ev = put(sto, item, priority = item.priority)
     else
-        put_ev = put(sto, item, item.priority) #regular put if no preemption or not at full capactiy
+        put_ev = put(sto, item, priority = item.priority) #regular put if no preemption or not at full capactiy
     end
     put_ev
 end

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -54,19 +54,13 @@ function put(sto::Store{T}, item::T, preempt::Bool=false, filter::Function=get_a
         get(sto, filter) #get item from store
         pitem = setdiff(stoitems, [itm for itm in sto.items])[1] #find removed item
         proc = pitem.process[sto] #process to interrupt
-        env = proc.bev.env #get environment
-        interrupt(proc,Preempted(item,now(env))) #interrupt process on removed item and create Preembed object
+        interrupt(proc, item) #interrupt process on removed item identify item causing the preemption
         #put new item into the queue
         put_ev = put(sto, item, priority = item.priority)
     else
         put_ev = put(sto, item, priority = item.priority) #regular put if no preemption or not at full capactiy
     end
     put_ev
-end
-
-mutable struct Preempted
-    by::T where T #identify which item caused the preemption
-    at::Float64 #time preemption occured
 end
 
 get_any_item(::T) where T = true


### PR DESCRIPTION
Preemption can be done on a `Store` object if an `item` of higher priority arrives. The amount of time the preempted object was served is stored.

This change adds a method to `put` that requires that the `item` have the following fields:
- `:priority::Int`: Integer specifying the priority of that `item` (the more
  negative, the higher the priority).
- `:process::Process`: The storage process
  of the `item`. This is used to know which `Process` to
  interrupt when preempting.

This addresses #61 

See example below:

```julia
using ResumableFunctions, SimJulia

#Define Job (item) to send to the queue (Store)
abstract type AbstractJob end
mutable struct Job <: AbstractJob
    id::Int
    arrival::Number
    priority::Int
    start_service::Number
    time_in_service::Number
    process::Union{Missing, SimJulia.Process}
    size::Number
end

#define a function to serve jobs that arrive at a queue and allow preemption
@resumable function serve(env, server, job)
    @yield timeout(env, job.arrival) #job arrives
    println("job $(job.id) enters queue at t = $(now(env))")
    while true
        try
            @yield put(server, job, true) #add job to queue, allow preemption
            println("Starting service on job $(job.id) at t = $(now(env)).")
            job.start_service = now(env) #save time service started on job
            @yield timeout(env, job.size - job.time_in_service) #service duration excludes any time already spent in service (if preempted)
            println("Service complete on job $(job.id) at t = $(now(env)).")
            job.time_in_service = now(env) - job.start_service #update time in serice
            get(server, x -> x.id == job.id) #remove job from queue
            break
        catch exc
            pre = exc.cause #find cause of preemption
            job.time_in_service = now(env) - job.start_service #update time in service
            println("Service on job $(job.id) interrupted (preempted) by job $(pre.id) at t = $(now(env)).")
        end
    end
end

#create simulation
sim = Simulation() #simulation object
server = Store{Job}(sim, capacity = UInt(1)) #server that processes jobs
job1 = Job(1,0,-1,0,0,missing,3) #add 3 jobs
job2 = Job(2,1,0,0,0,missing,3)
job3 = Job(3,2,-2,0,0,missing,3)

#create and store service processes
job1.process = @process serve(sim, server, job1)
job2.process = @process serve(sim, server, job2)
job3.process = @process serve(sim, server, job3)

#run simulation
run(sim)

#output
#=
job 1 enters queue at t = 0.0
Starting service on job 1 at t = 0.0.
job 2 enters queue at t = 1.0
job 3 enters queue at t = 2.0
Service on job 1 interrupted (preempted) by job 3 at t = 2.0.
Starting service on job 3 at t = 2.0.
Service complete on job 3 at t = 5.0.
Starting service on job 1 at t = 5.0.
Service complete on job 1 at t = 6.0.
Starting service on job 2 at t = 6.0.
Service complete on job 2 at t = 9.0.
=#

```