### PR TITLE
Make remove_callback more robust

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -59,7 +59,7 @@ macro callback(expr::Expr)
 end
 
 function remove_callback(cb::Function, ev::AbstractEvent)
-  i = indexin(ev.bev.callbacks, [cb])[1]
+  i = findfirst(x -> x == cb, ev.bev.callbacks)
   i != 0 && deleteat!(ev.bev.callbacks, i)
 end
 


### PR DESCRIPTION
If there is more than 1 callback on an event, there are issues when 
interrupting the event if the callback for the event target is not first 
in line.
This change makes it so that you can find the callback associated with 
the target and interrupt it. Otherwise, i = nothing and deleteat! will 
fail.